### PR TITLE
Discarding the master/slave terminology

### DIFF
--- a/web/helpdesk/migrations/0001_initial.py
+++ b/web/helpdesk/migrations/0001_initial.py
@@ -106,7 +106,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('name', models.CharField(max_length=100, verbose_name='Name')),
                 ('date', models.DateField(help_text='Date on which this e-mail address was added', verbose_name='Date', editable=False, blank=True)),
-                ('email_address', models.CharField(help_text='Enter a full e-mail address, or portions with wildcards, eg *@domain.com or postmaster@*.', max_length=150, verbose_name='E-Mail Address')),
+                ('email_address', models.CharField(help_text='Enter a full e-mail address, or portions with wildcards, eg *@domain.com or postmain@*.', max_length=150, verbose_name='E-Mail Address')),
                 ('keep_in_mailbox', models.BooleanField(default=False, help_text='Do you want to save emails from this address in the mailbox? If this is unticked, emails from this address will be deleted.', verbose_name='Save Emails in Mailbox?')),
             ],
             options={

--- a/web/helpdesk/models.py
+++ b/web/helpdesk/models.py
@@ -1036,7 +1036,7 @@ except:
 class IgnoreEmail(models.Model):
     """
     This model lets us easily ignore e-mails from certain senders when
-    processing IMAP and POP3 mailboxes, eg mails from postmaster or from
+    processing IMAP and POP3 mailboxes, eg mails from postmain or from
     known trouble-makers.
     """
     queues = models.ManyToManyField(
@@ -1063,7 +1063,7 @@ class IgnoreEmail(models.Model):
         _('E-Mail Address'),
         max_length=150,
         help_text=_('Enter a full e-mail address, or portions with '
-            'wildcards, eg *@domain.com or postmaster@*.'),
+            'wildcards, eg *@domain.com or postmain@*.'),
         )
 
     keep_in_mailbox = models.BooleanField(

--- a/world/dominion/domain/models.py
+++ b/world/dominion/domain/models.py
@@ -867,8 +867,8 @@ class Domain(CachedPropertiesMixin, SharedMemoryModel):
     num_farms = models.PositiveSmallIntegerField(default=0, blank=0)
     # workers who are not currently employed in a resource
     unassigned_serfs = models.PositiveIntegerField(default=0, blank=0)
-    # what proportion of our serfs are slaves and will have no money upkeep
-    slave_labor_percentage = models.PositiveSmallIntegerField(default=0, blank=0)
+    # what proportion of our serfs are subordinates and will have no money upkeep
+    subordinate_labor_percentage = models.PositiveSmallIntegerField(default=0, blank=0)
     # workers employed in different buildings
     mining_serfs = models.PositiveSmallIntegerField(default=0, blank=0)
     lumber_serfs = models.PositiveSmallIntegerField(default=0, blank=0)
@@ -995,12 +995,12 @@ class Domain(CachedPropertiesMixin, SharedMemoryModel):
 
     def worker_cost(self, number):
         """
-        Cost of workers, reduced if they are slaves
+        Cost of workers, reduced if they are subordinates
         """
-        if self.slave_labor_percentage > 99:
+        if self.subordinate_labor_percentage > 99:
             return 0
         cost = BASE_WORKER_COST * number
-        cost *= (100 - self.slave_labor_percentage)/100
+        cost *= (100 - self.subordinate_labor_percentage)/100
         if self.ruler and self.ruler.castellan:
             # every point in upkeep skill reduces cost
             reduction = 1.00 + self.get_bonus('upkeep')

--- a/world/dominion/general_dominion_commands.py
+++ b/world/dominion/general_dominion_commands.py
@@ -70,7 +70,7 @@ class CmdAdmDomain(ArxPlayerCommand):
       desc - description/history of domain
       area - total area of domain
       tax_rate
-      slave_labor_percentage
+      subordinate_labor_percentage
       num_farms - changes the number of farms to value
       num_mines - like farms
       num_mills - like farms
@@ -383,7 +383,7 @@ class CmdAdmDomain(ArxPlayerCommand):
         # to change them
         attr_switches = ("name", "desc", "title", "area", "stored_food", "tax_rate",
                          "num_mines", "num_lumber_yards", "num_mills", "num_housing",
-                         "num_farms", "unassigned_serfs", "slave_labor_percentage",
+                         "num_farms", "unassigned_serfs", "subordinate_labor_percentage",
                          "mining_serfs", "lumber_serfs", "farming_serfs", "mill_serfs",
                          "lawlessness", "amount_plundered", "income_modifier")
         switches = [switch for switch in self.switches if switch in attr_switches]

--- a/world/dominion/migrations/0001_initial.py
+++ b/world/dominion/migrations/0001_initial.py
@@ -192,7 +192,7 @@ class Migration(migrations.Migration):
                 ('num_housing', models.PositiveIntegerField(blank=0, default=0)),
                 ('num_farms', models.PositiveSmallIntegerField(blank=0, default=0)),
                 ('unassigned_serfs', models.PositiveIntegerField(blank=0, default=0)),
-                ('slave_labor_percentage', models.PositiveSmallIntegerField(blank=0, default=0)),
+                ('subordinate_labor_percentage', models.PositiveSmallIntegerField(blank=0, default=0)),
                 ('mining_serfs', models.PositiveSmallIntegerField(blank=0, default=0)),
                 ('lumber_serfs', models.PositiveSmallIntegerField(blank=0, default=0)),
                 ('farming_serfs', models.PositiveSmallIntegerField(blank=0, default=0)),

--- a/world/dominion/models.py
+++ b/world/dominion/models.py
@@ -1714,8 +1714,8 @@ class Domain(CachedPropertiesMixin, SharedMemoryModel):
     num_farms = models.PositiveSmallIntegerField(default=0, blank=0)
     # workers who are not currently employed in a resource
     unassigned_serfs = models.PositiveIntegerField(default=0, blank=0)
-    # what proportion of our serfs are slaves and will have no money upkeep
-    slave_labor_percentage = models.PositiveSmallIntegerField(default=0, blank=0)
+    # what proportion of our serfs are subordinates and will have no money upkeep
+    subordinate_labor_percentage = models.PositiveSmallIntegerField(default=0, blank=0)
     # workers employed in different buildings
     mining_serfs = models.PositiveSmallIntegerField(default=0, blank=0)
     lumber_serfs = models.PositiveSmallIntegerField(default=0, blank=0)
@@ -1842,12 +1842,12 @@ class Domain(CachedPropertiesMixin, SharedMemoryModel):
 
     def worker_cost(self, number):
         """
-        Cost of workers, reduced if they are slaves
+        Cost of workers, reduced if they are subordinates
         """
-        if self.slave_labor_percentage > 99:
+        if self.subordinate_labor_percentage > 99:
             return 0
         cost = BASE_WORKER_COST * number
-        cost *= (100 - self.slave_labor_percentage)/100
+        cost *= (100 - self.subordinate_labor_percentage)/100
         if self.ruler and self.ruler.castellan:
             # every point in upkeep skill reduces cost
             reduction = 1.00 + self.get_bonus('upkeep')


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.